### PR TITLE
Install rsync and openssh client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ncftp \
     python-boto \
     pwgen \
+    rsync \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 ENV HOME /root


### PR DESCRIPTION
I use duply with rsync over ssh but both are missing in your container. The patch installs rsync and openssh client from ubuntu sources.

Maybe it would be useful to add an parameter for `ssh-keygen` to your `entrypoint.sh` script too? 
