### PR TITLE
ssh v2 backend support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:trusty
 
-MAINTAINER Kurt Huwig
+LABEL maintainer="Kurt Huwig"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     duply \
     ncftp \
     python-boto \
+    python-paramiko \
     pwgen \
     rsync \
     openssh-client \


### PR DESCRIPTION
The ssh backend (duply targets ` ssh://` `scp://` and `sftp://`) requires the python package `python-paramiko` which is not installed in the duply image.

If you try to backup to an ssh2 target now you'll receive the error message `BackendException: Could not initialize backend: No module named paramiko`.

This can be resolved by installing the paramiko python package.

Notice: in ubuntu trusty it issues the warning `FutureWarning: CTR mode needs counter parameter, not IV` when using the ssh backend - see paramiko/paramiko/pull/714